### PR TITLE
Update to 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 bundler_args: --without development
 before_install:
   - gem update --system
-  - gem update bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '~> 1.14'
 cache: bundler
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 bundler_args: --without development
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '~> 1.14'
+  - gem install bundler -v '1.17.3'
+install:
+ - bundle _1.17.3_ install --jobs=3 --retry=3
 cache: bundler
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 bundler_args: --without development
 before_install:
-  - gem update --system
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '~> 1.14'
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'
-  gem 'rubocop', '>= 0.58.2', '< 0.70.0', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
+  gem 'rubocop', '>= 0.58.2', '< 0.69.0', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
   gem 'tins', '~> 1.13.0', :platforms => %i[jruby_18 jruby_19 ruby_19]
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'rack-test'
   gem 'rest-client', '~> 2.0.0', :platforms => [:jruby_18]
   gem 'rspec', '~> 3.5.0'
-  gem 'rubocop', '>= 0.58.2', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
+  gem 'rubocop', '>= 0.58.2', '< 0.70.0', :platforms => %i[ruby_20 ruby_21 ruby_22 ruby_23 ruby_24]
   gem 'tins', '~> 1.13.0', :platforms => %i[jruby_18 jruby_19 ruby_19]
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'coveralls', :require => false
-  gem 'hashie', '>= 3.4.6', '< 3.7.0', :platforms => [:jruby_18]
+  gem 'hashie', '>= 3.4.6', '~> 4.0.0', :platforms => [:jruby_18]
   gem 'json', '~> 2.0.3', :platforms => %i[jruby_18 jruby_19 ruby_19]
   gem 'mime-types', '~> 3.1', :platforms => [:jruby_18]
   gem 'rack', '>= 2.0.6', :platforms => %i[jruby_18 jruby_19 ruby_19 ruby_20 ruby_21]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ environment information on the callback request. It is entirely up to
 you how you want to implement the particulars of your application's
 authentication flow.
 
+**Please note:** there is currently a CSRF vulnerability that affects OmniAuth (designated [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)) that requires mitigation in application itself. More details on how to do this can be found in the [FAQ](https://github.com/omniauth/omniauth/wiki/FAQ#how-do-i-mitigate-cve-2015-9284).
+
 ## Configuring The `origin` Param
 The `origin` url parameter is typically used to inform where a user came from and where, should you choose to use it, they'd want to return to.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ environment information on the callback request. It is entirely up to
 you how you want to implement the particulars of your application's
 authentication flow.
 
-**Please note:** there is currently a CSRF vulnerability that affects OmniAuth (designated [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)) that requires mitigation in application itself. More details on how to do this can be found in the [FAQ](https://github.com/omniauth/omniauth/wiki/FAQ#how-do-i-mitigate-cve-2015-9284).
+**Please note:** there is currently a CSRF vulnerability which affects OmniAuth (designated [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)) that requires mitigation at the application level. More details on how to do this can be found in the [FAQ](https://github.com/omniauth/omniauth/wiki/FAQ#how-do-i-mitigate-cve-2015-9284).
 
 ## Configuring The `origin` Param
 The `origin` url parameter is typically used to inform where a user came from and where, should you choose to use it, they'd want to return to.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ environment information on the callback request. It is entirely up to
 you how you want to implement the particulars of your application's
 authentication flow.
 
-**Please note:** there is currently a CSRF vulnerability which affects OmniAuth (designated [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)) that requires mitigation at the application level. More details on how to do this can be found in the [FAQ](https://github.com/omniauth/omniauth/wiki/FAQ#how-do-i-mitigate-cve-2015-9284).
+**Please note:** there is currently a CSRF vulnerability which affects OmniAuth (designated [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)) that requires mitigation at the application level. More details on how to do this can be found on the [Wiki](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).
 
 ## Configuring The `origin` Param
 The `origin` url parameter is typically used to inform where a user came from and where, should you choose to use it, they'd want to return to.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 [![Gem Version](http://img.shields.io/gem/v/omniauth.svg)][gem]
 [![Build Status](http://img.shields.io/travis/omniauth/omniauth.svg)][travis]
-[![Dependency Status](http://img.shields.io/gemnasium/omniauth/omniauth.svg)][gemnasium]
 [![Code Climate](http://img.shields.io/codeclimate/github/omniauth/omniauth.svg)][codeclimate]
 [![Coverage Status](http://img.shields.io/coveralls/omniauth/omniauth.svg)][coveralls]
 [![Security](https://hakiri.io/github/omniauth/omniauth/master.svg)](https://hakiri.io/github/omniauth/omniauth/master)
 
 [gem]: https://rubygems.org/gems/omniauth
 [travis]: http://travis-ci.org/omniauth/omniauth
-[gemnasium]: https://gemnasium.com/omniauth/omniauth
 [codeclimate]: https://codeclimate.com/github/omniauth/omniauth
 [coveralls]: https://coveralls.io/r/omniauth/omniauth
 

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -132,7 +132,7 @@ module OmniAuth
   end
 
   module Utils
-    module_function
+  module_function # rubocop:disable Layout/IndentationWidth
 
     def form_css
       "<style type='text/css'>#{OmniAuth.config.form_css}</style>"

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -132,7 +132,7 @@ module OmniAuth
   end
 
   module Utils
-  module_function
+    module_function
 
     def form_css
       "<style type='text/css'>#{OmniAuth.config.form_css}</style>"

--- a/lib/omniauth/builder.rb
+++ b/lib/omniauth/builder.rb
@@ -1,16 +1,5 @@
 module OmniAuth
   class Builder < ::Rack::Builder
-    def initialize(app, &block)
-      @options = nil
-      if rack14? || rack2?
-        super
-      else
-        @app = app
-        super(&block)
-        @ins << @app
-      end
-    end
-
     def on_failure(&block)
       OmniAuth.config.on_failure = block
     end
@@ -32,7 +21,7 @@ module OmniAuth
     end
 
     def options(options = false)
-      return @options || {} if options == false
+      return @options ||= {} if options == false
 
       @options = options
     end
@@ -54,16 +43,6 @@ module OmniAuth
 
     def call(env)
       to_app.call(env)
-    end
-
-  private
-
-    def rack14?
-      Rack.release.start_with?('1.') && (Rack.release.split('.')[1].to_i >= 4)
-    end
-
-    def rack2?
-      Rack.release.start_with? '2.'
     end
   end
 end

--- a/lib/omniauth/builder.rb
+++ b/lib/omniauth/builder.rb
@@ -11,14 +11,6 @@ module OmniAuth
       end
     end
 
-    def rack14?
-      Rack.release.start_with?('1.') && (Rack.release.split('.')[1].to_i >= 4)
-    end
-
-    def rack2?
-      Rack.release.start_with? '2.'
-    end
-
     def on_failure(&block)
       OmniAuth.config.on_failure = block
     end
@@ -62,6 +54,16 @@ module OmniAuth
 
     def call(env)
       to_app.call(env)
+    end
+
+  private
+
+    def rack14?
+      Rack.release.start_with?('1.') && (Rack.release.split('.')[1].to_i >= 4)
+    end
+
+    def rack2?
+      Rack.release.start_with? '2.'
     end
   end
 end

--- a/lib/omniauth/failure_endpoint.rb
+++ b/lib/omniauth/failure_endpoint.rb
@@ -27,7 +27,7 @@ module OmniAuth
 
     def redirect_to_failure
       message_key = env['omniauth.error.type']
-      new_path = "#{env['SCRIPT_NAME']}#{OmniAuth.config.path_prefix}/failure?message=#{message_key}#{origin_query_param}#{strategy_name_query_param}"
+      new_path = "#{env['SCRIPT_NAME']}#{OmniAuth.config.path_prefix}/failure?message=#{Rack::Utils.escape(message_key)}#{origin_query_param}#{strategy_name_query_param}"
       Rack::Response.new(['302 Moved'], 302, 'Location' => new_path).finish
     end
 

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.9.0'.freeze
+  VERSION = '1.9.1'.freeze
 end

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,3 @@
 module OmniAuth
-  VERSION = '1.9.1'.freeze
+  VERSION = '1.9.2'.freeze
 end

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'hashie', ['>= 3.4.6', '~> 4.0.0']
+  spec.add_dependency 'hashie', ['>= 3.4.6']
   spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'hashie', ['>= 3.4.6', '< 3.7.0']
+  spec.add_dependency 'hashie', ['>= 3.4.6', '~> 4.0.0']
   spec.add_dependency 'rack', ['>= 1.6.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -8,8 +8,7 @@ if RUBY_VERSION >= '1.9'
   ]
 
   SimpleCov.start do
-    add_filter '/spec/'
-    add_filter '/vendor/'
+    add_filter ['/spec/', '/vendor/', 'strategy_macros.rb']
     minimum_coverage(92.5)
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,6 +10,7 @@ if RUBY_VERSION >= '1.9'
   SimpleCov.start do
     add_filter ['/spec/', '/vendor/', 'strategy_macros.rb']
     minimum_coverage(92.5)
+    maximum_coverage_drop(0.01)
   end
 end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,7 +10,7 @@ if RUBY_VERSION >= '1.9'
   SimpleCov.start do
     add_filter ['/spec/', '/vendor/', 'strategy_macros.rb']
     minimum_coverage(92.5)
-    maximum_coverage_drop(0.01)
+    maximum_coverage_drop(0.05)
   end
 end
 

--- a/spec/omniauth/builder_spec.rb
+++ b/spec/omniauth/builder_spec.rb
@@ -1,28 +1,6 @@
 require 'helper'
 
 describe OmniAuth::Builder do
-  describe '#initialize' do
-    let(:app) { lambda { |_env| [200, {}, []] } }
-    let(:prok) { proc {} }
-    let(:builder) { OmniAuth::Builder }
-
-    it 'calls original when rack 1.4' do
-      allow(Rack).to receive(:release).and_return('1.4.0')
-
-      expect(builder).to receive(:new).with(app, &prok).and_call_original
-
-      builder.new(app, &prok)
-    end
-
-    it 'calls original when rack 2' do
-      allow(Rack).to receive(:release).and_return('2.0.0')
-
-      expect(builder).to receive(:new).with(app, &prok).and_call_original
-
-      builder.new(app, &prok)
-    end
-  end
-
   describe '#provider' do
     it 'translates a symbol to a constant' do
       expect(OmniAuth::Strategies).to receive(:const_get).with('MyStrategy').and_return(Class.new)

--- a/spec/omniauth/builder_spec.rb
+++ b/spec/omniauth/builder_spec.rb
@@ -9,9 +9,17 @@ describe OmniAuth::Builder do
     it 'calls original when rack 1.4' do
       allow(Rack).to receive(:release).and_return('1.4.0')
 
-      expect(builder).to receive(:new).with(app).and_call_original
+      expect(builder).to receive(:new).with(app, &prok).and_call_original
 
-      builder.new(app)
+      builder.new(app, &prok)
+    end
+
+    it 'calls original when rack 2' do
+      allow(Rack).to receive(:release).and_return('2.0.0')
+
+      expect(builder).to receive(:new).with(app, &prok).and_call_original
+
+      builder.new(app, &prok)
     end
   end
 
@@ -66,9 +74,11 @@ describe OmniAuth::Builder do
     it 'passes the block to the config' do
       prok = proc {}
 
-      OmniAuth::Builder.new(nil).on_failure(&prok)
+      with_config_reset(:on_failure) do
+        OmniAuth::Builder.new(nil).on_failure(&prok)
 
-      expect(OmniAuth.config.on_failure).to eq(prok)
+        expect(OmniAuth.config.on_failure).to eq(prok)
+      end
     end
   end
 
@@ -76,9 +86,11 @@ describe OmniAuth::Builder do
     it 'passes the block to the config' do
       prok = proc {}
 
-      OmniAuth::Builder.new(nil).before_options_phase(&prok)
+      with_config_reset(:before_options_phase) do
+        OmniAuth::Builder.new(nil).before_options_phase(&prok)
 
-      expect(OmniAuth.config.before_options_phase).to eq(prok)
+        expect(OmniAuth.config.before_options_phase).to eq(prok)
+      end
     end
   end
 
@@ -86,9 +98,11 @@ describe OmniAuth::Builder do
     it 'passes the block to the config' do
       prok = proc {}
 
-      OmniAuth::Builder.new(nil).before_request_phase(&prok)
+      with_config_reset(:before_request_phase) do
+        OmniAuth::Builder.new(nil).before_request_phase(&prok)
 
-      expect(OmniAuth.config.before_request_phase).to eq(prok)
+        expect(OmniAuth.config.before_request_phase).to eq(prok)
+      end
     end
   end
 
@@ -96,9 +110,11 @@ describe OmniAuth::Builder do
     it 'passes the block to the config' do
       prok = proc {}
 
-      OmniAuth::Builder.new(nil).before_callback_phase(&prok)
+      with_config_reset(:before_callback_phase) do
+        OmniAuth::Builder.new(nil).before_callback_phase(&prok)
 
-      expect(OmniAuth.config.before_callback_phase).to eq(prok)
+        expect(OmniAuth.config.before_callback_phase).to eq(prok)
+      end
     end
   end
 
@@ -126,5 +142,11 @@ describe OmniAuth::Builder do
 
       expect(app).to have_received(:call).with(env)
     end
+  end
+
+  def with_config_reset(option)
+    old_config = OmniAuth.config.send(option)
+    yield
+    OmniAuth.config.send("#{option}=", old_config)
   end
 end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -242,7 +242,9 @@ describe OmniAuth::Strategy do
   describe '#redirect' do
     it 'uses javascript if :iframe is true' do
       response = ExampleStrategy.new(app, :iframe => true).redirect('http://abc.com')
-      expect(response.last.body.first).to be_include('top.location.href')
+      expected_body = "<script type='text/javascript' charset='utf-8'>top.location.href = 'http://abc.com';</script>"
+
+      expect(response.last).to include(expected_body)
     end
   end
 
@@ -653,8 +655,8 @@ describe OmniAuth::Strategy do
       end
 
       it 'maintains host and port' do
-        response = strategy.call(make_env('/auth/test', 'rack.url_scheme' => 'http', 'HTTP_HOST' => 'example.org', 'SERVER_PORT' => 3000))
-        expect(response[1]['Location']).to eq('http://example.org:3000/auth/test/callback')
+        response = strategy.call(make_env('/auth/test', 'rack.url_scheme' => 'http', 'SERVER_NAME' => 'example.org', 'SERVER_PORT' => 9292))
+        expect(response[1]['Location']).to eq('http://example.org:9292/auth/test/callback')
       end
 
       it 'maintains query string parameters' do


### PR DESCRIPTION
Merging the 1.9.2 changes into our fork. Afterwards we should start dismantling our fork, because our only patch is by now part of the 2.x line of Omniauth.